### PR TITLE
Use previous key mappings if they exist

### DIFF
--- a/plugin/hardtime.vim
+++ b/plugin/hardtime.vim
@@ -78,7 +78,7 @@ fun! HardTimeOn()
         exec "nnoremap <buffer> <silent> <expr> " . i . " TryKey('" . i . "') ? '" . (maparg(i, "n") != "" ? maparg(i, "n") : i) . "' : TooSoon()"
     endfor
     for i in g:list_of_visual_keys
-        exec "vnoremap <buffer> <silent> <expr> " . i . " TryKey('" . i . "') ? '" . (maparg(i, "n") != "" ? maparg(i, "n") : i) . "' : TooSoon()"
+        exec "vnoremap <buffer> <silent> <expr> " . i . " TryKey('" . i . "') ? '" . (maparg(i, "v") != "" ? maparg(i, "v") : i) . "' : TooSoon()"
     endfor
     if g:hardtime_showmsg
         echo "Hard time on"


### PR DESCRIPTION
While editing plain text documents, I map j and k keys to gj and gk respectively. However, hardtime ignores them. So, I fixed it.
