### PR TITLE
Fix error with recursive key mappings

### DIFF
--- a/plugin/hardtime.vim
+++ b/plugin/hardtime.vim
@@ -52,7 +52,6 @@ let s:lastkey = ''
 let s:lastcount = 0
 
 fun! s:HardTime()
-    let b:hardtime_on = 0
     let ignoreBuffer = s:IsIgnoreBuffer()
     if !ignoreBuffer
       call HardTimeOn()


### PR DESCRIPTION
Seems that vim may invoke BufRead more than once per buffer, so that our
function may be called twice that results in key will be mapped
recursively.
