### PR TITLE
Removed ! in 'autocmd BufRead,BufNewFile' 

### DIFF
--- a/plugin/hardtime.vim
+++ b/plugin/hardtime.vim
@@ -43,7 +43,7 @@ endif
 " Start hardtime in every buffer
 if exists("g:hardtime_default_on")
     if g:hardtime_default_on
-        autocmd! BufRead,BufNewFile * call s:HardTime()
+        autocmd BufRead,BufNewFile * call s:HardTime()
     endif
 endif
 


### PR DESCRIPTION
I have removed the ! in autocmd since my .vimrc contains another "autocmd BufNewFile *" which was overwrtiten by the !.I believe, it's more correct without the !.
