### PR TITLE
avoid showing message for new buffers

### DIFF
--- a/plugin/hardtime.vim
+++ b/plugin/hardtime.vim
@@ -60,7 +60,8 @@ fun! s:HardTime()
     let ignoreBuffer = s:IsIgnoreBuffer()
     let ignoreQuickfix = s:IsIgnoreQuickfix()
     if !ignoreBuffer && !ignoreQuickfix
-      call HardTimeOn()
+      let is_new_buffer = 1
+      call HardTimeOn(is_new_buffer)
     endif
 endf
 
@@ -77,7 +78,8 @@ fun! HardTimeOff()
     endif
 endf
 
-fun! HardTimeOn()
+fun! HardTimeOn(...)
+    let l:is_new_buffer = a:0 > 0 ? a:1 : 0
     if !exists("b:hardtime_on")
         let b:hardtime_on = 0
     endif
@@ -90,7 +92,7 @@ fun! HardTimeOn()
         for i in g:list_of_visual_keys
             exec "xnoremap <buffer> <silent> <expr> " . i . " TryKey('" . i . "') ? '" . (maparg(i, "v") != "" ? maparg(i, "v") : i) . "' : TooSoon()"
         endfor
-        if g:hardtime_showmsg
+        if g:hardtime_showmsg && !l:is_new_buffer
             echo "Hard time on"
         end
     endif


### PR DESCRIPTION
Every time I open a new buffer, I see the `Hard time on` message, then I have to press `enter` to actually start editing my file. 

![screenshot 2014-09-10 23 52 15](https://cloud.githubusercontent.com/assets/183363/4228687/75967d6a-3960-11e4-8b85-b467345a8ba6.png)

With this change we avoid showing this message for every new buffer.