### PR TITLE
Make completely disabling keys possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ down the page using `jjjjj` and `kkkkk` but without compromising the rest of our
 experience.
 
 It works using a timeout on the keys you want to stop repeating, i.e. `h`, `j`, `k`, `l`, `UP`, `DOWN`, `LEFT`, `RIGHT`.
-This timeout is set to 1000 milliseconds. After this time you can use a movement key again.
+This timeout is set to 1000 milliseconds. After this time you can use a movement key again. It also allows to completely disable
+keys that you never under any circumstances want to use.
 
 Stop repeating jjjjj...
 Stop repeating kkkk...
@@ -44,6 +45,9 @@ Defaults to
 	g:list_of_normal_keys = ["h", "j", "k", "l", "-", "+", "<UP>", "<DOWN>", "<LEFT>", "<RIGHT>"]
 	g:list_of_visual_keys = ["h", "j", "k", "l", "-", "+", "<UP>", "<DOWN>", "<LEFT>", "<RIGHT>"]
 	g:list_of_insert_keys = ["<UP>", "<DOWN>", "<LEFT>", "<RIGHT>"]
+	g:list_of_disabled_keys = []
+
+Note that the keys added to `g:list_of_disabled_keys` are disabled in all of normal, visual and insert modes.
 
 ##### Timeout
 It is possible to tweak the timeout allowed between keypresses. specifying

--- a/plugin/hardtime.vim
+++ b/plugin/hardtime.vim
@@ -17,6 +17,7 @@ endf
 call s:check_defined("g:list_of_visual_keys", ["h", "j", "k", "l", "-", "+", "<UP>", "<DOWN>", "<LEFT>", "<RIGHT>"])
 call s:check_defined("g:list_of_normal_keys", ["h", "j", "k", "l", "-", "+", "<UP>", "<DOWN>", "<LEFT>", "<RIGHT>"])
 call s:check_defined("g:list_of_insert_keys", ["<UP>", "<DOWN>", "<LEFT>", "<RIGHT>"])
+call s:check_defined("g:list_of_disabled_keys", [])
 
 call s:check_defined("g:hardtime_default_on", 0)
 call s:check_defined("g:hardtime_ignore_buffer_patterns", [])
@@ -57,6 +58,11 @@ fun! HardTimeOn()
         for i in g:list_of_insert_keys
             exec "inoremap <buffer> <silent> <expr> " . i . " TryKey('" . i . "') ? '" . (maparg(i, "i") != "" ? maparg(i, "i") : i) . "' : TooSoon()"
         endfor
+        for i in g:list_of_disabled_keys
+            exec "nnoremap <buffer> <silent> " . i . " <nop>"
+            exec "xnoremap <buffer> <silent> " . i . " <nop>"
+            exec "inoremap <buffer> <silent> " . i . " <nop>"
+        endfor
     endif
 endf
 
@@ -69,6 +75,11 @@ fun! HardTimeOff()
         exec "silent! vunmap <buffer> " . i
     endfor
     for i in g:list_of_insert_keys
+        exec "silent! iunmap <buffer> " . i
+    endfor
+    for i in g:list_of_disabled_keys
+        exec "silent! nunmap <buffer> " . i
+        exec "silent! xunmap <buffer> " . i
         exec "silent! iunmap <buffer> " . i
     endfor
 endf


### PR DESCRIPTION
All keys that are defined in g:list_of_disabled_keys are completely
disabled in n, v, i modes instead of given a delay. This basically
implements what is described in
http://vimcasts.org/blog/2013/02/habit-breaking-habit-making/ and
allows for hardtime to manage the \<nop\>'ed keys.

I am aware that the original hardmode plugin implements something similar to this, but this implementation is somewhat more flexible in that the disabled keys are not hard-coded in.