### PR TITLE
HardTimeToggle invalid variable error

### DIFF
--- a/plugin/hardtime.vim
+++ b/plugin/hardtime.vim
@@ -86,7 +86,7 @@ endf
 
 
 fun! HardTimeToggle()
-	call s:check_defined("g:hardtime_on", 0)
+	call s:check_defined("b:hardtime_on", 0)
     if b:hardtime_on
         call HardTimeOff()
 		if g:hardtime_showmsg


### PR DESCRIPTION
If `g:hardtime_default_on = 0`, when calling `HardTimeToggle` will result in a invalid variable error.
Chaging `g:hardtime_on` to `b:hardtime_on` in `HardTimeToggle` function shoud fix this error.