### PR TITLE
Fix movement while in visual mode

### DIFF
--- a/plugin/hardtime.vim
+++ b/plugin/hardtime.vim
@@ -73,7 +73,7 @@ fun! HardTimeOff()
         exec "silent! nunmap <buffer> " . i
     endfor
     for i in g:list_of_visual_keys
-        exec "silent! vunmap <buffer> " . i
+        exec "silent! xunmap <buffer> " . i
     endfor
     for i in g:list_of_insert_keys
         exec "silent! iunmap <buffer> " . i

--- a/plugin/hardtime.vim
+++ b/plugin/hardtime.vim
@@ -54,7 +54,7 @@ fun! HardTimeOn()
             exec "nnoremap <buffer> <silent> <expr> " . i . " TryKey('" . i . "') ? '" . (maparg(i, "n") != "" ? maparg(i, "n") : i) . "' : TooSoon()"
         endfor
         for i in g:list_of_visual_keys
-            exec "xnoremap <buffer> <silent> <expr> " . i . " TryKey('" . i . "') ? '" . (maparg(i, "v") != "" ? maparg(i, "v") : i) . "' : TooSoon()"
+            exec "xnoremap <buffer> <silent> <expr> " . i . " TryKey('" . i . "') ? '" . (maparg(i, "x") != "" ? maparg(i, "x") : i) . "' : TooSoon()"
         endfor
         for i in g:list_of_insert_keys
             exec "inoremap <buffer> <silent> <expr> " . i . " TryKey('" . i . "') ? '" . (maparg(i, "i") != "" ? maparg(i, "i") : i) . "' : TooSoon()"


### PR DESCRIPTION
The use of `maparg()` with 'v' instead of 'x' inside `xnoremap` commands applied in `HardTimeOn` was preventing movement with any keys controlled under `g:list_of_visual_keys` while in visual mode. My assumption is this was unintentionally missed in 7ac74ef36404f1cc1b17abd56a011311a33f526f. 

Also includes a change to use `xunmap` in `HardTimeOff` to match the usage of `xnoremap` in `HardTimeOn`.

Thanks for the really handy plugin!