### PR TITLE
Compatible remapping with other plugins

### DIFF
--- a/plugin/hardtime.vim
+++ b/plugin/hardtime.vim
@@ -50,6 +50,9 @@ fun! s:RetrieveMapping(key, mode)
     if !has_key(mapping, "rhs") || mapping["rhs"] == ""
         return "'" . a:key . "'"
     endif
+    if  has_key(mapping, "sid")
+        let mapping["rhs"] = substitute(mapping["rhs"], "<SID>", "<SNR>".mapping["sid"]."_", "")
+    endif
     " If mapping is an expression, don't quote
     if mapping["expr"]
         return mapping["rhs"]


### PR DESCRIPTION
This changes allow to use mappings that might be redefined by other plugins (such as vim-arpeggio) 