### PR TITLE
enabled hardtime even in "No Name" buffers when hardtime_default_on is set

### DIFF
--- a/plugin/hardtime.vim
+++ b/plugin/hardtime.vim
@@ -30,7 +30,7 @@ call s:check_defined("g:hardtime_maxcount", 1)
 
 " Start hardtime in every buffer
 if g:hardtime_default_on
-	autocmd BufRead,BufNewFile * call s:HardTime()
+	autocmd BufWinEnter * call s:HardTime()
 endif
 
 let s:lasttime = 0


### PR DESCRIPTION
I was experiencing same problem described in #54 (hardtime not enabled in "No Name" buffers) and I fixed #54 using the suggested change in the issue.