### PR TITLE
Revert commit that broke vim-fugitive

### DIFF
--- a/plugin/hardtime.vim
+++ b/plugin/hardtime.vim
@@ -32,7 +32,7 @@ call s:check_defined("g:hardtime_maxcount", 1)
 
 " Start hardtime in every buffer
 if g:hardtime_default_on
-	autocmd BufWinEnter * call s:HardTime()
+	autocmd BufRead,BufNewFile * call s:HardTime()
 endif
 
 let s:lasttime = 0


### PR DESCRIPTION
Revert "enabled hardtime even in "No Name" buffers when hardtime_default_on is set (#54)"

This reverts commit 5603072377d1f1f26a1561eda9e1884bb5f028ef.

## Motivation

It breaks vim-fugitive as well as `s:IsIgnoreBuffer`, so
that I cannot escape the file. This means I (and possibly many others)
cannot use git with the new change.

## To reproduce fugitive error:

1. Open vim
2. Open git status with `:G`
3. Go to a change you want to stage
4. Press `-`

Result:

![image](https://user-images.githubusercontent.com/17277051/161695965-c291b710-eb97-446d-9b7b-551b0dda3fc9.png)
